### PR TITLE
optimize testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ openstack_heat_plugin_venafi.egg-info
 dist
 build
 openstack-heat-plugin-venafi/__pycache__/
+openstack-heat-plugin-venafi/resources/__pycache__/
+openstack-heat-plugin-venafi/resources/tests/__pycache__/

--- a/openstack-heat-plugin-venafi/resources/tests/test_venafi_certificate.py
+++ b/openstack-heat-plugin-venafi/resources/tests/test_venafi_certificate.py
@@ -173,6 +173,9 @@ class TestVenafiCertificate:
         )
         assert pkey_public_key_pem == cert_public_key_pem
 
+        #after performing the validations, then just remove the created stack
+        client.stacks.delete(stack_randomized_name)
+
     # Testing random string template to check that Heat is operating normally.
     # def test_random_string(self):
     #     self._prepare_tests("random_string.yml", 'random_string_stack_', None)


### PR DESCRIPTION
When running tests all creates tacks aren't removed, so remove created stack after validations and in that way have a clean openstack server instance.