### PR TITLE
increase the wait time for restarting devstack before launching the test suite

### DIFF
--- a/openstack-heat-plugin-venafi/resources/tests/install_venafi_certificate_plugin.py
+++ b/openstack-heat-plugin-venafi/resources/tests/install_venafi_certificate_plugin.py
@@ -31,7 +31,7 @@ def install():
     result = run('sudo systemctl restart devstack@h-eng')
     print(result)
     # TODO: rewrite sleep to check of "systemctl status devstack@h-eng"
-    time.sleep(10)
+    time.sleep(20)
     try:
         result = run('journalctl -q -u devstack@h-eng.service --since '
                        '"2 minutes ago"|grep "OS::Nova::VenafiCertificate"')


### PR DESCRIPTION
Tested against jenkins instance about 6 times, and all rans were with 0 errors.